### PR TITLE
Added textcolor and backgroundcolor in draw_string

### DIFF
--- a/kandinsky.py
+++ b/kandinsky.py
@@ -51,8 +51,8 @@ def set_pixel(x, y, color):
     #pygame.draw.rect(usable, (red, green, blue), pygame.rect.Rect(x, y, 1, 1))
 
 
-def draw_string(text, x, y):
-    screen.blit(font.render(text, True, (0, 0, 0)), (x*scale, (y+18)*scale))
+def draw_string(text, x, y, textcolor = (0, 0, 0), backgroundcolor = (255,255,255)):
+    screen.blit(font.render(text, True, textcolor, backgroundcolor), (x*scale, (y+18)*scale))
     pygame.display.flip()
 
 


### PR DESCRIPTION
According with these lines : https://github.com/numworks/epsilon/blob/4f76e4418fbeacfa17f603ae4f67a2a8df4cdf9e/python/port/mod/kandinsky/modkandinsky.cpp#L70-L71
Warning : not tested, because 
![image](https://user-images.githubusercontent.com/43498612/75705988-bea03980-5cbc-11ea-90ca-ee1bfa819565.png)
